### PR TITLE
Add Pagination, Fix env TOKEN reference from readme, allow wildcard cdn domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ To get a local copy up and running follow these simple example steps.
    ```sh
    npm install
    ```
-6. Create a `.env.local` file and add your INSTAGRAM_TOKEN
+6. Create a `.env.local` file and add your NEXT_PUBLIC_INSTAGRAM_TOKEN
    ```js
-   INSTAGRAM_TOKEN=.....;
+   NEXT_PUBLIC_INSTAGRAM_TOKEN=.....;
    ```
 7. Run your app with
    ```sh

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "scontent.cdninstagram.com",
+        hostname: "*.cdninstagram.com",
         port: "",
       },
     ],


### PR DESCRIPTION
- add pagination to feed query
- fix broken reference from README of env token (README showed `env.INSTAGRAM_TOKEN` while code used `env.IG_TOKEN`) -> make it `env.NEXT_PUBLIC_INSTAGRAM_TOKEN` and using a client component
- support all Instagram cdn domains using `hostname: "*.cdninstagram.com"` in `next.config` instead of only `scontent.cdninstagram.com`